### PR TITLE
Properly register parameters of LU decomposition

### DIFF
--- a/glow/modules.py
+++ b/glow/modules.py
@@ -208,8 +208,8 @@ class InvertibleConv1x1(nn.Module):
             l_mask = np.tril(np.ones(w_shape, dtype=np.float32), -1)
             eye = np.eye(*w_shape, dtype=np.float32)
 
-            self.p = torch.Tensor(np_p.astype(np.float32))
-            self.sign_s = torch.Tensor(np_sign_s.astype(np.float32))
+            self.p = nn.Parameter(torch.Tensor(np_p.astype(np.float32)))
+            self.sign_s = nn.Parameter(torch.Tensor(np_sign_s.astype(np.float32)))
             self.l = nn.Parameter(torch.Tensor(np_l.astype(np.float32)))
             self.log_s = nn.Parameter(torch.Tensor(np_log_s.astype(np.float32)))
             self.u = nn.Parameter(torch.Tensor(np_u.astype(np.float32)))

--- a/glow/modules.py
+++ b/glow/modules.py
@@ -208,8 +208,8 @@ class InvertibleConv1x1(nn.Module):
             l_mask = np.tril(np.ones(w_shape, dtype=np.float32), -1)
             eye = np.eye(*w_shape, dtype=np.float32)
 
-            self.p = nn.Parameter(torch.Tensor(np_p.astype(np.float32)))
-            self.sign_s = nn.Parameter(torch.Tensor(np_sign_s.astype(np.float32)))
+            self.register_buffer('p', torch.Tensor(np_p.astype(np.float32)))
+            self.register_buffer('sign_s', torch.Tensor(np_sign_s.astype(np.float32)))
             self.l = nn.Parameter(torch.Tensor(np_l.astype(np.float32)))
             self.log_s = nn.Parameter(torch.Tensor(np_log_s.astype(np.float32)))
             self.u = nn.Parameter(torch.Tensor(np_u.astype(np.float32)))


### PR DESCRIPTION
Currently when `lu_decomposed` is set to `True`, loading from a checkpoint doesn't work.

This PR fixes that by properly registering them as a buffer so they will be part of the state dict.